### PR TITLE
Fix typo dateFile

### DIFF
--- a/bot/app.js
+++ b/bot/app.js
@@ -666,7 +666,7 @@ class Application {
                     type: 'stdout'
                 },
                 outfile: {
-                    type: 'DateFile',
+                    type: 'dateFile',
                     filename: path.join(botConfig.logsDir, 'access-log'),
                     pattern: 'yyyy-MM-dd.log',
                     alwaysIncludePattern: true,

--- a/dmsrc/common/index.js
+++ b/dmsrc/common/index.js
@@ -22,7 +22,7 @@ class BaseDanmakuWebSocketSource {
             appenders: {
                 stdout: { type: 'stdout' },
                 outfile: {
-                    type: 'DateFile',
+                    type: 'dateFile',
                     filename: path.join(config.logsDir, 'access-log'),
                     pattern: 'yyyy-MM-dd.log',
                     alwaysIncludePattern: true,


### PR DESCRIPTION
```
appender "outfile" is not valid (type "DateFile" could not be found)
```
Change `DateFile` to `dateFile` works for me.

A official example for "dateFile": https://log4js-node.github.io/log4js-node/migration-guide.html